### PR TITLE
fix: remove version and -ti options

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   ok-api:
     image: ok-api
@@ -8,5 +6,3 @@ services:
       dockerfile: Dockerfile
     ports:
       - "8080:8080"
-    stdin_open: true   # Keep STDIN open even if not attached
-    tty: true          # Allocate a pseudo-TTY


### PR DESCRIPTION
These options are not needed in the compose file
